### PR TITLE
Simplify markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link href="src/styles.css" rel="stylesheet" />
   </head>
 
-  <body>
+  <body ondragstart="return false;" ondrop="return false;">
     <div id="app"></div>
     <button id="play-chord">Reset</button>
 

--- a/src/osc.ts
+++ b/src/osc.ts
@@ -16,12 +16,8 @@ function createNoteOsc(freq: number, index: number) {
 
   const oscs = Nodes.oscs
 
-  const oscCtrl = h('div')
-  oscCtrl.classList.add('osc-ctrl')
-
   const volumeCtrl = h('div')
   volumeCtrl.classList.add('volume')
-  container.appendChild(oscCtrl)
   drawbar.appendChild(volumeCtrl)
 
   let osc: OscillatorNode
@@ -33,7 +29,7 @@ function createNoteOsc(freq: number, index: number) {
     if (osc) {
       osc.stop()
     }
-    oscCtrl.classList.remove('playing')
+    drawbar.classList.remove('playing')
   }
 
   const start = () => {
@@ -46,13 +42,13 @@ function createNoteOsc(freq: number, index: number) {
     osc.frequency.setValueAtTime(freq, ctx.currentTime)
     osc.connect(oscGain)
     osc.start()
-    oscCtrl.classList.add('playing')
+    drawbar.classList.add('playing')
   }
 
   const calculateVolume = (offsetY: number) => {
     const perceptionProportion = 1 / ((index + 1) * 1.1)
     // console.log(perceptionProportion);
-    const maxHeight = parseInt(getComputedStyle(oscCtrl).height, 10)
+    const maxHeight = parseInt(getComputedStyle(drawbar).height, 10)
     const volume = Math.min(
       ((maxHeight - offsetY) / maxHeight) * perceptionProportion,
       1
@@ -69,11 +65,11 @@ function createNoteOsc(freq: number, index: number) {
     paint = false
   })
 
-  oscCtrl.addEventListener('dblclick', () => {
+  drawbar.addEventListener('dblclick', () => {
     calculateVolume(300)
   })
 
-  oscCtrl.addEventListener("mousedown", (e: MouseEvent) => {
+  drawbar.addEventListener('mousedown', (e: MouseEvent) => { 
     calculateVolume(e.offsetY)
     if (!isPlaying) {
       start()
@@ -81,7 +77,7 @@ function createNoteOsc(freq: number, index: number) {
     }
   })
   
-  oscCtrl.addEventListener('mousemove', (e: MouseEvent) => {
+  drawbar.addEventListener('mousemove', (e: MouseEvent) => {
     if (paint) {
       calculateVolume(e.offsetY)
       if(!isPlaying){

--- a/src/osc.ts
+++ b/src/osc.ts
@@ -8,10 +8,10 @@ function createNoteOsc(freq: number, index: number) {
   let paint = false
   const volume = 0.3
 
-  const container = h('div')
-  container.classList.add('note')
+  const drawbar = h('div')
+  drawbar.classList.add('drawbar')
   if (index % 7 === 0) {
-    container.classList.add('root')
+    drawbar.classList.add('root')
   }
 
   const oscs = Nodes.oscs
@@ -21,8 +21,8 @@ function createNoteOsc(freq: number, index: number) {
 
   const volumeCtrl = h('div')
   volumeCtrl.classList.add('volume')
-  container.appendChild(volumeCtrl)
   container.appendChild(oscCtrl)
+  drawbar.appendChild(volumeCtrl)
 
   let osc: OscillatorNode
   const oscGain = ctx.createGain()
@@ -91,7 +91,7 @@ function createNoteOsc(freq: number, index: number) {
     }
   })
 
-  Nodes.oscs.appendChild(container)
+  Nodes.oscs.appendChild(drawbar)
 
   return () => {
     stop()

--- a/src/osc.ts
+++ b/src/osc.ts
@@ -4,7 +4,6 @@ import { getMajorScale } from './scales'
 
 function createNoteOsc(freq: number, index: number) {
   let isPlaying = false
-  let isMouseDown = false
   let paint = false
   const volume = 0.3
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -6,7 +6,7 @@
   max-height: 300px;
 }
 
-.note {
+.drawbar {
   margin: 0;
   width: auto;
   height: 100%;
@@ -14,23 +14,17 @@
   position: relative;
   flex-grow: 1;
 }
-.note.root {
+.drawbar.root {
   background: grey;
 }
-.note.playing {
+.drawbar.playing {
   box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.5);
 }
-.note .osc-ctrl {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-}
-.note .volume {
+.drawbar .volume {
   background: red;
   opacity: 0.5;
   position: absolute;
   bottom: 0;
   width: 100%;
+  pointer-events: none;
 }


### PR DESCRIPTION
## Context

Didn't see any benefit from having 2 children divs per note, renamed note to drawbar and ported behavior and logic from child oscCtrl to parent drawbar. :)

## Changes

- Rename container to drawbar
- Replace delete oscCtrl and replace with drawbar

## GIF

![GIF](https://media4.giphy.com/media/IHnROpQICe4kE/giphy.gif?cid=6104955eee150ee2ea16074ea2438a7554dd9b7c5d467de6&rid=giphy.gif&ct=g&cid=6104955eee150ee2ea16074ea2438a7554dd9b7c5d467de6&rid=giphy.gif&ct=g)